### PR TITLE
start crashReporter in renderer

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1,5 +1,15 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
+const {crashReporter} = require('electron')
+
+crashReporter.start({
+  productName: 'MPStudio',
+  companyName: 'Motorized Precision',
+  submitURL: 'https://pacific-falls-32011.herokuapp.com/',
+  autoSubmit: true,
+  ignoreSystemCrashHandler: false,
+  extra: {'test': 'test'}
+})
 
 process.crash()


### PR DESCRIPTION
According to the docs you need to start the `crashReporter` in the renderer process also.

> You are required to call this (`crashReporter.start`) method before using any other crashReporter APIs and in each process (main/renderer) from which you want to collect crash reports.

https://github.com/electron/electron/blob/v1.6.8/docs/api/crash-reporter.md#crashreporterstartoptions